### PR TITLE
관심 사용자 등록 및 삭제 API 연동

### DIFF
--- a/src/app/constants/URI.ts
+++ b/src/app/constants/URI.ts
@@ -1,2 +1,1 @@
 export const BASE_URL: string = import.meta.env.VITE_API_URL as string;
-export const BASE_PYTHON_URL: string = import.meta.env.VITE_PYTHON_URL as string;

--- a/src/hooks/profile/useInterestUser.tsx
+++ b/src/hooks/profile/useInterestUser.tsx
@@ -1,0 +1,28 @@
+import { fetchInstance } from "@/app/config/axios";
+import { useMutation } from "@tanstack/react-query";
+
+const registerInterestingUser = async (userId: number): Promise<void> => {
+    const response = await fetchInstance.post(`api/user/interest/${userId}`, {
+        toUser: userId,
+    });
+    return response.data;
+};
+
+const deleteInterestingUser = async (userId: number): Promise<void> => {
+    await fetchInstance.delete(`/api/user/interest/${userId}`);
+};
+
+export const useInterestUser = () => {
+    const registerMutation = useMutation({
+        mutationFn: (userId: number) => registerInterestingUser(userId),
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: (userId: number) => deleteInterestingUser(userId),
+    });
+
+    return {
+        registerInterest: registerMutation.mutate,
+        deleteInterest: deleteMutation.mutate,
+    };
+};

--- a/src/pages/profile/UserPage.tsx
+++ b/src/pages/profile/UserPage.tsx
@@ -7,11 +7,17 @@ import { useState } from "react";
 import { History } from "@/components/profile/History";
 import { Box } from "@/components/common/Box";
 import { InbodyInfo } from "@/components/profile/InbodyInfo";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
+import { useInterestUser } from "@/hooks/profile/useInterestUser";
 
 export const UserPage = () => {
     const [isPost, setIsPost] = useState(true);
     const [isLiked, setIsLiked] = useState(false);
+
+    const { id } = useParams<{ id: string }>();
+    console.log(id);
+    const userId = parseInt(id ?? "");
+    const { registerInterest, deleteInterest } = useInterestUser();
 
     const navigate = useNavigate();
 
@@ -24,7 +30,15 @@ export const UserPage = () => {
     };
 
     const handleLikeClick = () => {
-        setIsLiked((prev) => !prev);
+        if (isLiked) {
+            deleteInterest(userId, {
+                onSuccess: () => setIsLiked(false),
+            });
+        } else {
+            registerInterest(userId, {
+                onSuccess: () => setIsLiked(true),
+            });
+        }
     };
 
     const handleChatClick = (id: number) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,4 +8,13 @@ export default defineConfig({
     resolve: {
         alias: [{ find: "@", replacement: path.resolve(__dirname, "src") }],
     },
+    server: {
+        proxy: {
+            "/api": {
+                target: process.env.VITE_API_URL,
+                changeOrigin: true,
+                secure: false,
+            },
+        },
+    },
 });


### PR DESCRIPTION
## 🔧 작업 내용

- useInterestUser 훅 구현 -> deleteInterest, registerInterest 
- UserPage 에 관심 사용자 등록 및 삭제 api 연동
- vite procxy setting

<br>

## 📌 참고 사항

<br>

## ❗️ 현재 버그

<br>

## ✓ Git close

- Resolve #72 
